### PR TITLE
changing font size on code of conduct page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10380,9 +10380,6 @@
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "requires": {
             "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"

--- a/shared/components/ConferenceCodeOfConduct/index.scss
+++ b/shared/components/ConferenceCodeOfConduct/index.scss
@@ -48,8 +48,8 @@
 @media (min-width: $tablet-portrait-width) {
   .CodeOfConduct__intro {
     h3, h4, * {
-      line-height: 31px;
-      font-size: 24px;
+      line-height: 56px;
+      font-size: 48px;
     }
   }
 


### PR DESCRIPTION
Acceptance criteria:

- Font size for header text on Code of Conduct page should be 20px