### PR TITLE
reducing font size on code of conduct page

### DIFF
--- a/shared/components/ConferenceCodeOfConduct/index.scss
+++ b/shared/components/ConferenceCodeOfConduct/index.scss
@@ -48,8 +48,8 @@
 @media (min-width: $tablet-portrait-width) {
   .CodeOfConduct__intro {
     h3, h4, * {
-      line-height: 31px;
-      font-size: 24px;
+      line-height: 16px;
+      font-size: 12px;
     }
   }
 


### PR DESCRIPTION
Acceptance criteria:

- Font size of Code of Conduct header text should be 20px